### PR TITLE
Make the unminified code the "main" version on npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,6 @@
 .gitignore
-node_modules
 contrib
+build-core.js
+asq.js
+*tests*
+legacy.js

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,2 @@
 .gitignore
 contrib
-build-core.js
-asq.js
-*tests*
-legacy.js

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "asynquence",
 	"version": "0.5.4-a",
 	"description": "asynquence: promise-style async sequence flow-control",
-	"main": "./asq.js",
+	"main": "./asq.src.js",
 	"scripts": {
 		"test": "./node-tests.js",
 		"build-core": "./build-core.js"


### PR DESCRIPTION
I noticed that multiple versions of the library were being published to npm in this package: the unminified code, the minified code, and the legacy code.

I cleaned up the .npmignore a bit to remove some unnecessary files.

I also made a change to match my preference (and I think convention?) that the unminified version be published to npm.  I prefer to be able to trace into the libraries that I use (and get readable stack traces, when the case arises), and minify them all together manually before I deploy my npm-installed modules to the browser.

If you're dead-set on pushing minified code to npm, I can switch it back, but please consider just publishing the readable version to npm.

<3

- removed unnecessary node_modules line in .npmignore
- added ancillary test/build files to .npmignore
- changed package.json to publish the unminified version of the library